### PR TITLE
fix: replace dead auction URLs (vweb2.brevardclerk + bare realforeclose)

### DIFF
--- a/.claude/tasks/sprint5-enrichment-completion.md
+++ b/.claude/tasks/sprint5-enrichment-completion.md
@@ -40,7 +40,7 @@ DOR fl_parcels table (Supabase):
 ```
 
 ```
-Brevard Clerk Foreclosure Page: http://vweb2.brevardclerk.us/Foreclosures/foreclosure_sales.html
+Brevard Clerk Foreclosure Page: http://www.brevardclerk.us/Foreclosures/foreclosure_sales.html
   Format: HTML table with columns: case_number, case_title, comment, foreclosure_sale_date
   case_title: "PLAINTIFF VS DEFENDANT" — parse both sides
   Defendant → BCPAO OWNER_NAME1 lookup → parcel_id, address, building details


### PR DESCRIPTION
## Summary\n- Replaces dead `vweb2.brevardclerk.us` URLs with working `www.brevardclerk.us`\n- Replaces dead bare `www.realforeclose.com` / `realforeclose.com/index.cfm?county=15` with per-county `brevard.realforeclose.com` subdomain\n- Part of SUMMIT #432 — Brevard Auction Data Freshness Triage\n\n## Context\n- `vweb2.brevardclerk.us` HTTPS is ERR_CONNECTION_REFUSED (dead over HTTPS)\n- `www.realforeclose.com` / bare `realforeclose.com` DNS is dead (ERR_NAME_NOT_RESOLVED)\n- Verified replacements return HTTP 200 from Hetzner\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)